### PR TITLE
Auto Sync Registry if no codemod available

### DIFF
--- a/src/executeMainThread.ts
+++ b/src/executeMainThread.ts
@@ -1,7 +1,7 @@
 import * as readline from 'node:readline';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { handleListNamesCommand } from './handleListCliCommand.js';
+import { handleListNamesAfterSyncing } from './handleListCliCommand.js';
 import { CodemodDownloader } from './downloadCodemod.js';
 import { Printer } from './printer.js';
 import { handleLearnCliCommand } from './handleLearnCliCommand.js';
@@ -110,7 +110,6 @@ export const executeMainThread = async () => {
 	}
 
 	const argv = await Promise.resolve(argvObject.argv);
-
 	const fetchBuffer = async (url: string) => {
 		const { data } = await Axios.get(url, {
 			responseType: 'arraybuffer',
@@ -158,7 +157,7 @@ export const executeMainThread = async () => {
 
 	if (String(argv._) === 'list') {
 		try {
-			await handleListNamesCommand(argv, printer, fileDownloadService, tarService, true);
+			await handleListNamesAfterSyncing(argv.useCache, printer, fileDownloadService, tarService, true);
 		} catch (error) {
 			if (!(error instanceof Error)) {
 				return;
@@ -176,7 +175,7 @@ export const executeMainThread = async () => {
 	}
 
 	if (String(argv._) === 'syncRegistry') {
-		await syncRegistryOperation(argv, printer, fileDownloadService, tarService)
+		await syncRegistryOperation(argv.useCache, printer, fileDownloadService, tarService)
 		exit();
 
 		return;
@@ -347,7 +346,7 @@ export const executeMainThread = async () => {
 };
 
 export async function syncRegistryOperation(
-	argv: any,
+	useCache: boolean,
 	printer: Printer,
 	fileDownloadService: FileDownloadService,
 	tarService: TarService,
@@ -355,7 +354,7 @@ export async function syncRegistryOperation(
 	const codemodDownloader = new CodemodDownloader(
 	  printer,
 	  join(homedir(), '.intuita'),
-	  argv.useCache,
+	  useCache,
 	  fileDownloadService,
 	  tarService,
 	);

--- a/src/handleListCliCommand.ts
+++ b/src/handleListCliCommand.ts
@@ -49,7 +49,6 @@ export const handleListNamesAfterSyncing = async (
 	printer: Printer,
 	fileDownloadService: FileDownloadService,
 	tarService: TarService,
-	syncRegistry: boolean,
 ) => {
 	await syncRegistryOperation(useCache, printer, fileDownloadService, tarService)
 	await handleListNamesCommand(printer)

--- a/src/handleListCliCommand.ts
+++ b/src/handleListCliCommand.ts
@@ -10,13 +10,7 @@ import { FileDownloadService } from './fileDownloadService.js';
 import { syncRegistryOperation } from './executeMainThread.js'
 import { TarService } from './services/tarService.js';
 
-export const handleListNamesCommand = async (
-	argv: any,
-	printer: Printer,
-	fileDownloadService: FileDownloadService,
-	tarService: TarService,
-	syncRegistry: boolean,
-) => {
+export const handleListNamesCommand = async (printer: Printer) => {
 	const configurationDirectoryPath = join(homedir(), '.intuita');
 
 	await mkdir(configurationDirectoryPath, { recursive: true });
@@ -47,13 +41,16 @@ export const handleListNamesCommand = async (
 
 	const names = v.parse(v.array(v.string()), onlyValid);
 
-	// Sync with registry if there are no codemods available
-	if (syncRegistry && Object.keys(names).length === 0) {
-		printer.printOperationMessage({ kind: 'status', message: "There were no codemod synced, hence syncing it with registry" });
-		await syncRegistryOperation(argv, printer, fileDownloadService, tarService)
-
-		await handleListNamesCommand(argv, printer, fileDownloadService, tarService, false)
-	}
-
 	printer.printOperationMessage({ kind: 'names', names });
 };
+
+export const handleListNamesAfterSyncing = async (
+	useCache: boolean,
+	printer: Printer,
+	fileDownloadService: FileDownloadService,
+	tarService: TarService,
+	syncRegistry: boolean,
+) => {
+	await syncRegistryOperation(useCache, printer, fileDownloadService, tarService)
+	await handleListNamesCommand(printer)
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -53,6 +53,11 @@ export type ErrorMessage = Readonly<{
 	path?: string;
 }>;
 
+export type StatusUpdateMessage = Readonly<{
+	kind: 'status';
+	message: string;
+}>;
+
 export type OperationMessage =
 	| RewriteMessage
 	| FinishMessage
@@ -63,4 +68,5 @@ export type OperationMessage =
 	| CopyMessage
 	| MetadataPathMessage
 	| NamesMessage
-	| ErrorMessage;
+	| ErrorMessage
+	| StatusUpdateMessage;


### PR DESCRIPTION
# Summary 

Using `codemod list` without having codemods available in the local directory, shows nothing to users 

Users are supposed to perform 'codemod syncRegistry' first and then use `codemod list` 

First time users will not have any idea about codemod syncRegistry, hence adding a function to *auto-sync* if no codemods are available in the local directory 

# Test

- Tested locally by deleting all codemods in /users/harsh-gupta/.intuita directory and checking syncRegistry is being called on using codemod list 

- if there are codemods available, then codemod list just shows the codemods available 

Tried writing a test, but vitest doesn't have a good way to set up local directory and I was running into an error, might have to start using jest. 